### PR TITLE
replacing the query parameter by the basic authentication user name

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -30,8 +30,9 @@ type Authenticator interface {
 // this function should return the list of authorized actions and a nil error. an empty list must be returned
 // if requesting user is unauthorized
 type Authorizer interface {
-	Authorize(req *AuthorizationRequest, username string) ([]string, error)
+	Authorize(req *AuthorizationRequest) ([]string, error)
 }
+
 // TokenGenerator: an implementation should create a valid JWT according to the spec here
 // https://github.com/docker/distribution/blob/1b9ab303a477ded9bdd3fc97e9119fa8f9e58fca/docs/spec/auth/jwt.md
 // a default implementation that follows the spec is used when it is not provided
@@ -49,7 +50,7 @@ func (d *DefaultAuthenticator) Authenticate(username, password string) error {
 // DefaultAuthorizer makes authorization successful by default
 type DefaultAuthorizer struct{}
 
-func (d *DefaultAuthorizer) Authorize(req *AuthorizationRequest, username string) ([]string, error) {
+func (d *DefaultAuthorizer) Authorize(req *AuthorizationRequest) ([]string, error) {
 	return []string{"pull", "push"}, nil
 }
 


### PR DESCRIPTION
The Docker registry says that the `sub` JWT attribute must be the name of the authenticated account;
https://docs.docker.com/registry/spec/auth/jwt/#getting-a-bearer-token 

Thus, `AuthorizationRequest.Account` must be fixed to use the username that comes in the basic authorisation header, the username in the query parameter (it is a security breach btw!).
And since the `AuthorizationRequest.Account` will be the username, we do not need to pass an extra param